### PR TITLE
Added ul and ol tags to parse lists

### DIFF
--- a/markdown_i18n/parser.py
+++ b/markdown_i18n/parser.py
@@ -9,8 +9,7 @@ from babel.messages.catalog import Catalog
 from babel.messages import pofile
 from babel.support import Translations
 
-
-TRANSLATE_TAGS_RE = re.compile('^(p|h[1-6])$')
+TRANSLATE_TAGS_RE = re.compile('^(ul|p|h[1-6])$')
 
 
 class I18NTreeProcessor(Treeprocessor):

--- a/markdown_i18n/parser.py
+++ b/markdown_i18n/parser.py
@@ -9,7 +9,7 @@ from babel.messages.catalog import Catalog
 from babel.messages import pofile
 from babel.support import Translations
 
-TRANSLATE_TAGS_RE = re.compile('^(ul|p|h[1-6])$')
+TRANSLATE_TAGS_RE = re.compile('^(ol|ul|p|h[1-6])$')
 
 
 class I18NTreeProcessor(Treeprocessor):

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -158,12 +158,23 @@ class I18nTest(unittest.TestCase):
     def test_ulists(self):
         text = "* First element.\n * Second element.\n"
         expected = """<ul>
-<li>First element.</li>
+<li>Primer elemento.</li>
 
-<li>Second element.</li>
+<li>Segundo elemento.</li>
 </ul>"""
         with TempDir() as d:
             c = catalog.Catalog(locale='es_ES')
+            c.add(
+                """
+<li>First element.</li>
+
+<li>Second element.</li>
+""", """
+<li>Primer elemento.</li>
+
+<li>Segundo elemento.</li>
+"""
+            )
             os.mkdir(os.path.join(d.dir, 'es_ES'))
             lc_messages = os.path.join(d.dir, 'es_ES', 'LC_MESSAGES')
             os.mkdir(lc_messages)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -194,12 +194,23 @@ class I18nTest(unittest.TestCase):
     def test_nlists(self):
         text = "1. First element.\n 2. Second element.\n"
         expected = """<ol>
-<li>First element.</li>
+<li>Primer elemento.</li>
 
-<li>Second element.</li>
+<li>Segundo elemento.</li>
 </ol>"""
         with TempDir() as d:
             c = catalog.Catalog(locale='es_ES')
+            c.add(
+                """
+<li>First element.</li>
+
+<li>Second element.</li>
+""", """
+<li>Primer elemento.</li>
+
+<li>Segundo elemento.</li>
+"""
+            )
             os.mkdir(os.path.join(d.dir, 'es_ES'))
             lc_messages = os.path.join(d.dir, 'es_ES', 'LC_MESSAGES')
             os.mkdir(lc_messages)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -155,6 +155,57 @@ class I18nTest(unittest.TestCase):
                 )
             self.assertEqual(expected, result)
 
+    def test_ulists(self):
+        text = "* First element.\n * Second element.\n"
+        expected = """<ul>
+<li>First element.</li>
+
+<li>Second element.</li>
+</ul>"""
+        with TempDir() as d:
+            c = catalog.Catalog(locale='es_ES')
+            os.mkdir(os.path.join(d.dir, 'es_ES'))
+            lc_messages = os.path.join(d.dir, 'es_ES', 'LC_MESSAGES')
+            os.mkdir(lc_messages)
+            mo_file = os.path.join(lc_messages, 'messages.mo')
+            with open(mo_file, 'w') as f:
+                mofile.write_mo(f, c)
+
+            result = markdown(
+                text,
+                extensions=['markdown_i18n'],
+                extension_configs={
+                    'markdown_i18n': {'i18n_dir': d.dir, 'i18n_lang': 'es_ES'}
+                }
+            )
+        self.assertEqual(expected, result)
+
+    def test_nlists(self):
+        text = "1. First element.\n 2. Second element.\n"
+        expected = """<ol>
+<li>First element.</li>
+
+<li>Second element.</li>
+</ol>"""
+        with TempDir() as d:
+            c = catalog.Catalog(locale='es_ES')
+            os.mkdir(os.path.join(d.dir, 'es_ES'))
+            lc_messages = os.path.join(d.dir, 'es_ES', 'LC_MESSAGES')
+            os.mkdir(lc_messages)
+            mo_file = os.path.join(lc_messages, 'messages.mo')
+            with open(mo_file, 'w') as f:
+                mofile.write_mo(f, c)
+
+            result = markdown(
+                text,
+                extensions=['markdown_i18n'],
+                extension_configs={
+                    'markdown_i18n': {'i18n_dir': d.dir,
+                                      'i18n_lang': 'es_ES'}
+                }
+            )
+        self.assertEqual(expected, result)
+
     def test_merge_existing_pot(self):
         with TempDir() as d:
             pot_file = os.path.join(d.dir, 'messages.pot')


### PR DESCRIPTION
List strings are not being parsed.

- Added tags 'ul' and 'ol' to parser to translate list strings.
- Added tests for **ul** lists
- Added tests for **ol** lists