### PR TITLE
Unitary li elements

### DIFF
--- a/markdown_i18n/parser.py
+++ b/markdown_i18n/parser.py
@@ -30,11 +30,9 @@ class I18NTreeProcessor(Treeprocessor):
                 ])
                 if translatable:
                     catalog.add(translatable)
-                    content = '<{0}>{1}</{0}>'.format(
-                        child.tag, translations.gettext(translatable)
-                    )
                     try:
-                        new_node = etree.fromstring(content.encode('utf-8'))
+                        new_node = etree.Element(child.tag, **child.attrib)
+                        new_node.text = translations.gettext(translatable)
                         root.remove(child)
                         root.insert(idx, new_node)
                     except etree.ParseError:

--- a/markdown_i18n/parser.py
+++ b/markdown_i18n/parser.py
@@ -9,7 +9,7 @@ from babel.messages.catalog import Catalog
 from babel.messages import pofile
 from babel.support import Translations
 
-TRANSLATE_TAGS_RE = re.compile('^(ol|ul|p|h[1-6]|th|td)$')
+TRANSLATE_TAGS_RE = re.compile('^(li|p|h[1-6]|th|td)$')
 
 
 class I18NTreeProcessor(Treeprocessor):

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -169,17 +169,8 @@ class I18nTest(unittest.TestCase):
 </ul>"""
         with TempDir() as d:
             c = catalog.Catalog(locale='es_ES')
-            c.add(
-                """
-<li>First element.</li>
-
-<li>Second element.</li>
-""", """
-<li>Primer elemento.</li>
-
-<li>Segundo elemento.</li>
-"""
-            )
+            c.add("First element.", "Primer elemento.")
+            c.add("Second element.", "Segundo elemento.")
             os.mkdir(os.path.join(d.dir, 'es_ES'))
             lc_messages = os.path.join(d.dir, 'es_ES', 'LC_MESSAGES')
             os.mkdir(lc_messages)
@@ -194,7 +185,7 @@ class I18nTest(unittest.TestCase):
                     'markdown_i18n': {'i18n_dir': d.dir, 'i18n_lang': 'es_ES'}
                 }
             )
-        self.assertEqual(expected, result)
+        self.assertEqual(clean_xml(expected), clean_xml(result))
 
     def test_nlists(self):
         text = "1. First element.\n 2. Second element.\n"
@@ -205,17 +196,8 @@ class I18nTest(unittest.TestCase):
 </ol>"""
         with TempDir() as d:
             c = catalog.Catalog(locale='es_ES')
-            c.add(
-                """
-<li>First element.</li>
-
-<li>Second element.</li>
-""", """
-<li>Primer elemento.</li>
-
-<li>Segundo elemento.</li>
-"""
-            )
+            c.add("First element.", "Primer elemento.")
+            c.add("Second element.", "Segundo elemento.")
             os.mkdir(os.path.join(d.dir, 'es_ES'))
             lc_messages = os.path.join(d.dir, 'es_ES', 'LC_MESSAGES')
             os.mkdir(lc_messages)
@@ -231,7 +213,7 @@ class I18nTest(unittest.TestCase):
                                       'i18n_lang': 'es_ES'}
                 }
             )
-        self.assertEqual(expected, result)
+        self.assertEqual(clean_xml(expected), clean_xml(result))
 
     def test_merge_existing_pot(self):
         with TempDir() as d:


### PR DESCRIPTION
- Support for `<li>` unitary elements
- Use of `etree.Element` to create new tag and maintain original attributes 