### PR TITLE
Fix no remove <code> tags

### DIFF
--- a/markdown_i18n/parser.py
+++ b/markdown_i18n/parser.py
@@ -25,8 +25,7 @@ class I18NTreeProcessor(Treeprocessor):
                 translatable = child.text or ''
                 translatable += '\n'.join([
                     etree.tostring(c) for c in
-                        child.getchildren() if
-                            c.tag != 'code'
+                        child.getchildren()
                 ])
                 if translatable:
                     catalog.add(translatable)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -271,3 +271,16 @@ Content 1     | Content 2
         )
 
         self.assertEqual(clean_xml(expected), clean_xml(result))
+
+    def test_code_tag(self):
+        text = 'ports like: `"com1", "com2"`'
+        expected = '<p>puertos como: <code>"com1", "com2"</code></p>'
+
+        self.catalog.add(
+            'ports like: <code>"com1", "com2"</code>',
+            'puertos como:<code>"com1", "com2"</code>'
+        )
+        self.write_mo()
+
+        result = self.markdown(text)
+        self.assertEqual(clean_xml(result), clean_xml(expected))


### PR DESCRIPTION
Fixes #18 

Before we remove `<code>` tags to no translate code parts, but when is code is inside a `<pre>` tag which is no translatable then never will enter.